### PR TITLE
Ignore mplayer's stdout to keep it from stopping playback

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -22,7 +22,9 @@ function playSong () {
     })
   var song = files[Math.floor(Math.random() * files.length)]
 
-  var m = spawn(MPLAYER, [path.join(MUSIC_DIR, song)])
+  var m = spawn(MPLAYER, [path.join(MUSIC_DIR, song)], {
+    stdio: ['pipe', 'ignore', 'ignore'],
+  })
   m.fade = function () {
     var n = 10
     var i = setInterval(function () {


### PR DESCRIPTION
On OSX anyway, mplayer will stop playback if its stdout buffer fills up.  This change sets up the mplayer child process to send its stdout and stderr to /dev/null.